### PR TITLE
Add PyBaMM DCA transformer notebook

### DIFF
--- a/pybamm_dca_transformer.ipynb
+++ b/pybamm_dca_transformer.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Differential Capacity Analysis with PyBaMM and Transformer\n",
+    "This notebook generates synthetic differential capacity analysis (DCA) curves using [PyBaMM](https://www.pybamm.org/) with randomized parameters. A simple Transformer model is then trained to predict the open circuit potential (OCP) curve from the DCA data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install compatible package versions\n",
+    "!pip install pybamm==25.6.0 torch==2.3.0 numpy==1.26.4 --quiet\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pybamm\n",
+    "import torch\n",
+    "import numpy as np\n",
+    "from torch import nn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def simulate_dca(ocp_scale=1.0, pos_diffusivity=1e-14, particle_radius=1e-6):\n",
+    "    param = pybamm.ParameterValues(\n",
+    "        {\n",
+    "            'Positive electrode diffusivity [m2.s-1]': pos_diffusivity,\n",
+    "            'Positive particle radius [m]': particle_radius,\n",
+    "        }\n",
+    "    )\n",
+    "    model = pybamm.lithium_ion.DFN()\n",
+    "    # Scale the positive electrode OCP with a custom function\n",
+    "    def ocp_mod(c):\n",
+    "        return ocp_scale * pybamm.lithium_ion.stephan_2013.positive_electrode_ocp(c)\n",
+    "    param.update({'Positive electrode OCP [V]': ocp_mod})\n",
+    "    sim = pybamm.Simulation(model, parameter_values=param)\n",
+    "    t_eval = np.linspace(0, 3600, 200)\n",
+    "    sim.solve(t_eval=t_eval)\n",
+    "    Q = sim.solution['Discharge capacity [A.h]'].data\n",
+    "    V = sim.solution['Terminal voltage [V]'].data\n",
+    "    dQdV = np.gradient(Q, V)\n",
+    "    return V, dQdV, ocp_mod\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate synthetic dataset\n",
+    "num_samples = 10000  # modify for a smaller demonstration if needed\n",
+    "seq_len = 200\n",
+    "dca_data = np.zeros((num_samples, seq_len))\n",
+    "ocp_curves = np.zeros((num_samples, seq_len))\n",
+    "voltage_axis = None\n",
+    "\n",
+    "for i in range(num_samples):\n",
+    "    ocp_scale = 0.95 + 0.1 * np.random.rand()\n",
+    "    diff = 1e-14 * 10**np.random.uniform(-1, 1)\n",
+    "    radius = 1e-6 * 10**np.random.uniform(-1, 1)\n",
+    "    V, dQdV, ocp_fun = simulate_dca(ocp_scale, diff, radius)\n",
+    "    if voltage_axis is None:\n",
+    "        voltage_axis = V\n",
+    "    dca_data[i] = dQdV\n",
+    "    ocp_curves[i] = ocp_fun(pybamm.Array(V)).entries\n",
+    "\n",
+    "np.savez('dca_dataset.npz', X=dca_data, y=ocp_curves, V=voltage_axis)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simple Transformer model for seq2seq OCP prediction\n",
+    "class SeqTransformer(nn.Module):\n",
+    "    def __init__(self, seq_len, d_model=64, nhead=8, num_layers=2):\n",
+    "        super().__init__()\n",
+    "        self.pos = nn.Parameter(torch.randn(seq_len, d_model))\n",
+    "        encoder_layer = nn.TransformerEncoderLayer(d_model, nhead)\n",
+    "        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers)\n",
+    "        self.fc = nn.Linear(d_model, 1)\n",
+    "    def forward(self, x):\n",
+    "        x = x + self.pos\n",
+    "        h = self.encoder(x)\n",
+    "        out = self.fc(h)\n",
+    "        return out.squeeze(-1)\n",
+    "\n",
+    "model = SeqTransformer(seq_len)\n",
+    "criterion = nn.MSELoss()\n",
+    "optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prepare data loaders\n",
+    "X = torch.tensor(dca_data, dtype=torch.float32)\n",
+    "y = torch.tensor(ocp_curves, dtype=torch.float32)\n",
+    "dataset = torch.utils.data.TensorDataset(X, y)\n",
+    "loader = torch.utils.data.DataLoader(dataset, batch_size=32, shuffle=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Training loop (short example)\n",
+    "for epoch in range(5):\n",
+    "    for batch_x, batch_y in loader:\n",
+    "        optimizer.zero_grad()\n",
+    "        pred = model(batch_x)\n",
+    "        loss = criterion(pred, batch_y)\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "    print(f'Epoch {epoch+1}:', loss.item())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- add a new notebook `pybamm_dca_transformer.ipynb` showing how to generate differential capacity analysis data with PyBaMM and train a simple Transformer model to predict OCP curves
- specify exact PyBaMM, Torch and NumPy versions to avoid install conflicts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684580e2449c832e92b7409f226bdb79